### PR TITLE
Fixes on rST syntax, and a typo introduced in previous commit

### DIFF
--- a/source/conventions.rst
+++ b/source/conventions.rst
@@ -77,7 +77,7 @@ Should receive as parameters:
 
 * :param int action_id: id of the action where to perform the redirection
 * :param string button_text: text to put on the button that will trigger
-the redirection.
+                             the redirection.
 
 AccessDenied
 ############

--- a/source/environment.rst
+++ b/source/environment.rst
@@ -242,7 +242,7 @@ It will modifiy the current Records in RecordSet after a rebrowse and will gener
 
 
 Changing User
-############
+#############
 
 Environment provides an helper to switch user: ::
 

--- a/source/fields.rst
+++ b/source/fields.rst
@@ -34,7 +34,7 @@ Now fields are class property: ::
 Field inheritance
 ------------------
 
-One of the new features of the API is too be able to change only one attribute of the field: ::
+One of the new features of the API is to be able to change only one attribute of the field: ::
 
    name = fields.Char(string='New Value')
 
@@ -290,6 +290,7 @@ This allows to have fields definition atop of class: ::
 
 The function can be void.
 It should modify record property in order to be written to the cache: ::
+
   self.name = new_value
 
 Be aware that this assignation will trigger a write into the database.


### PR DESCRIPTION
with `make html` I've found 3 warnings, fixed below
